### PR TITLE
Add helper Makefile (make clean, make build, make run).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# Quick helpers for common tasks
+
+clean:
+	bundle exec jekyll clean
+
+build: clean
+	bundle exec jekyll build
+
+run: clean
+	bundle exec jekyll serve --incremental


### PR DESCRIPTION
This adds a Makefile which shortcuts jekyll clean, build, and serve.

- `make clean`
- `make build`
- `make run`