### PR TITLE
Feature/basic schemadotorg review support

### DIFF
--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -2,6 +2,7 @@
 layout: post
 ---
 <div itemscope itemtype="http://schema.org/Review">
+
   {%- if page.winery_details -%}
     <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Winery">
       <h1><a href="{{ page.winery_details.url }}" itemprop="url"><span itemprop="name">{{ page.winery_details.name }}</span></a></h1>
@@ -17,11 +18,11 @@ layout: post
     </ul>
   {%- endif -%}
 
-<h1>Review</h1>
-<meta itemprop=name content="{{ page.title }}">
-<meta itemprop=author itemscope itemtype="http://schema.org/Person" content="{{ page.author }}">
-<span itemprop="reviewBody">
-  {{ content }}
-</span>
+  <h1>Review</h1>
+  <meta itemprop=name content="{{ page.title }}">
+  <meta itemprop=author itemscope itemtype="http://schema.org/Person" content="{{ page.author }}">
+  <span itemprop="reviewBody">
+    {{ content }}
+  </span>
 
 </div>

--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -18,8 +18,8 @@ layout: post
   {%- endif -%}
 
 <h1>Review</h1>
-<meta itemprop=name itemscope itemtype="http://schema.org/Person" content="{{ page.title }}">
-<meta itemprop=author content="{{ page.author }}">
+<meta itemprop=name content="{{ page.title }}">
+<meta itemprop=author itemscope itemtype="http://schema.org/Person" content="{{ page.author }}">
 <span itemprop="reviewBody">
   {{ content }}
 </span>

--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -2,26 +2,26 @@
 layout: post
 ---
 <div itemscope itemtype="http://schema.org/Review">
-  <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Winery">
-    {%- if page.winery_details -%}
+  {%- if page.winery_details -%}
+    <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Winery">
       <h1><a href="{{ page.winery_details.url }}" itemprop="url"><span itemprop="name">{{ page.winery_details.name }}</span></a></h1>
       <meta itemprop="servesCuisine" content="Wine">
-  </div>
-      <ul>
-        <li><span itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
-          Rating: <span itemprop="ratingValue">{{ page.winery_details.rating }}</span> 
-          out of <span itemprop="bestRating">100</span>
-          </span></li>
-        <li>Tasting Fee: {{ page.winery_details.tasting }}</li>
-        <li>Reservation Required: {{ page.winery_details.reservation }}</li>
-      </ul>
-    {%- endif -%}
+    </div>
+    <ul>
+      <li><span itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+        Rating: <span itemprop="ratingValue">{{ page.winery_details.rating }}</span> 
+        out of <span itemprop="bestRating">100</span>
+        </span></li>
+      <li>Tasting Fee: {{ page.winery_details.tasting }}</li>
+      <li>Reservation Required: {{ page.winery_details.reservation }}</li>
+    </ul>
+  {%- endif -%}
 
-    <h1>Review</h1>
-    <meta itemprop=name itemscope itemtype="http://schema.org/Person" content="{{ page.title }}">
-    <meta itemprop=author content="{{ page.author }}">
-    <span itemprop="reviewBody">
-      {{ content }}
-    </span>
+<h1>Review</h1>
+<meta itemprop=name itemscope itemtype="http://schema.org/Person" content="{{ page.title }}">
+<meta itemprop=author content="{{ page.author }}">
+<span itemprop="reviewBody">
+  {{ content }}
+</span>
 
 </div>

--- a/_layouts/review.html
+++ b/_layouts/review.html
@@ -1,14 +1,27 @@
 ---
 layout: post
 ---
-{%- if page.winery_details -%}
-  <h1><a href="{{ page.winery_details.url }}">{{ page.winery_details.name }}</a></h1>
-  <ul>
-    <li>Rating: {{ page.winery_details.rating }} out of 100</li>
-    <li>Tasting Fee: {{ page.winery_details.tasting }}</li>
-    <li>Reservation Required: {{ page.winery_details.reservation }}</li>
-  </ul>
-{%- endif -%}
+<div itemscope itemtype="http://schema.org/Review">
+  <div itemprop="itemReviewed" itemscope itemtype="http://schema.org/Winery">
+    {%- if page.winery_details -%}
+      <h1><a href="{{ page.winery_details.url }}" itemprop="url"><span itemprop="name">{{ page.winery_details.name }}</span></a></h1>
+      <meta itemprop="servesCuisine" content="Wine">
+  </div>
+      <ul>
+        <li><span itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating">
+          Rating: <span itemprop="ratingValue">{{ page.winery_details.rating }}</span> 
+          out of <span itemprop="bestRating">100</span>
+          </span></li>
+        <li>Tasting Fee: {{ page.winery_details.tasting }}</li>
+        <li>Reservation Required: {{ page.winery_details.reservation }}</li>
+      </ul>
+    {%- endif -%}
 
-<h1>Review</h1>
-{{ content }}
+    <h1>Review</h1>
+    <meta itemprop=name itemscope itemtype="http://schema.org/Person" content="{{ page.title }}">
+    <meta itemprop=author content="{{ page.author }}">
+    <span itemprop="reviewBody">
+      {{ content }}
+    </span>
+
+</div>


### PR DESCRIPTION
Modifications to the _layout/review.html template that adds schema.org metadata support for thing:review of thing:winery. Primarily uses front matter metadata. The important parts parse correctly with https://search.google.com/structured-data/testing-tool.