### PR TITLE
Correctly fix CNAME

### DIFF
--- a/.circleci/deploy-ghpages.sh
+++ b/.circleci/deploy-ghpages.sh
@@ -38,7 +38,6 @@ else
 fi
 
 # copy over or recompile the new site
-cp -a ../CNAME .
 cp -a "../${siteSource}/." .
 
 # stage any changes and new files

--- a/_config.yml
+++ b/_config.yml
@@ -54,5 +54,4 @@ exclude:
   - vendor
   - Gemfile
   - Gemfile.lock
-  - CNAME
   - README.md


### PR DESCRIPTION
Revert 821937dff496353750810304f1481b2d6f042344.
Fix CNAME by not excluding it in jekyll config.